### PR TITLE
feat: add Fun.retinue

### DIFF
--- a/src/Fun.ml
+++ b/src/Fun.ml
@@ -2,12 +2,12 @@ open StdlibShim
 
 module Deep =
 struct
-  let retinue k f =
+  let finally k f =
     match f () with
     | x -> Effect.Deep.continue k x
     | exception e -> Effect.Deep.discontinue k e
 
-  let retinue_preserving_backtrace k f =
+  let finally_preserving_backtrace k f =
     match f () with
     | x -> Effect.Deep.continue k x
     | exception e ->
@@ -17,12 +17,12 @@ end
 
 module Shallow =
 struct
-  let retinue_with k f h =
+  let finally_with k f h =
     match f () with
     | x -> Effect.Shallow.continue_with k x h
     | exception e -> Effect.Shallow.discontinue_with k e h
 
-  let retinue_preserving_backtrace_with k f h =
+  let finally_preserving_backtrace_with k f h =
     match f () with
     | x -> Effect.Shallow.continue_with k x h
     | exception e ->

--- a/src/Fun.ml
+++ b/src/Fun.ml
@@ -1,0 +1,31 @@
+open StdlibShim
+
+module Deep =
+struct
+  let retinue k f =
+    match f () with
+    | x -> Effect.Deep.continue k x
+    | exception e -> Effect.Deep.discontinue k e
+
+  let retinue_preserving_backtrace k f =
+    match f () with
+    | x -> Effect.Deep.continue k x
+    | exception e ->
+      let bt = Printexc.get_raw_backtrace () in
+      Effect.Deep.discontinue_with_backtrace k e bt
+end
+
+module Shallow =
+struct
+  let retinue_with k f h =
+    match f () with
+    | x -> Effect.Shallow.continue_with k x h
+    | exception e -> Effect.Shallow.discontinue_with k e h
+
+  let retinue_preserving_backtrace_with k f h =
+    match f () with
+    | x -> Effect.Shallow.continue_with k x h
+    | exception e ->
+      let bt = Printexc.get_raw_backtrace () in
+      Effect.Shallow.discontinue_with_backtrace k e bt h
+end

--- a/src/Fun.mli
+++ b/src/Fun.mli
@@ -1,0 +1,30 @@
+open StdlibShim
+
+module Deep :
+sig
+
+  val retinue : ('a, 'b) Effect.Deep.continuation -> (unit -> 'a) -> 'b
+  (**
+     There are cases where one wants to resume a continuation with an expression, regardless of whether the expression will raise an exception or not. The current OCaml API forces us to choose between [continue] and [discontinue], depending on whether the expression is returning a value or raising an exception. I am tired of writing the boilerplate to redirect the value/exception. This simple function will do the right thing in both cases. Usage:
+     {[
+       Eff.Fun.Deep.retinue k @@ fun () -> some OCaml expression
+     ]}
+  *)
+
+  val retinue_preserving_backtrace : ('a, 'b) Effect.Deep.continuation -> (unit -> 'a) -> 'b
+  (**
+     A variant of {!val:retinue} that preserves the backtrace of the exception thrown by the expression. I am still not sure whether this is in general a good idea, because the backtrace associated with the original {!val:Effect.perform} could potentially be more useful for debugging than that associated with the {!val:raise} inside the OCaml expression. (This is different from exception handling where original backtraces are probably always better.)
+     {[
+       Eff.Fun.Deep.retinue_preserving_backtrace k @@ fun () -> some OCaml expression
+     ]}
+  *)
+end
+
+module Shallow :
+sig
+  val retinue_with : ('a, 'b) Effect.Shallow.continuation -> (unit -> 'a) -> ('b, 'c) Effect.Shallow.handler -> 'c
+  (** See {!val:Deep.retinue}. *)
+
+  val retinue_preserving_backtrace_with : ('a, 'b) Effect.Shallow.continuation -> (unit -> 'a) -> ('b, 'c) Effect.Shallow.handler -> 'c
+  (** See {!val:Deep.retinue_preserving_backtrace}. *)
+end

--- a/src/Fun.mli
+++ b/src/Fun.mli
@@ -3,28 +3,28 @@ open StdlibShim
 module Deep :
 sig
 
-  val retinue : ('a, 'b) Effect.Deep.continuation -> (unit -> 'a) -> 'b
+  val finally : ('a, 'b) Effect.Deep.continuation -> (unit -> 'a) -> 'b
   (**
      There are cases where one wants to resume a continuation with an expression, regardless of whether the expression will raise an exception or not. The current OCaml API forces us to choose between [continue] and [discontinue], depending on whether the expression is returning a value or raising an exception. I am tired of writing the boilerplate to redirect the value/exception. This simple function will do the right thing in both cases. Usage:
      {[
-       Eff.Fun.Deep.retinue k @@ fun () -> some OCaml expression
+       Eff.Fun.Deep.finally k @@ fun () -> some OCaml expression
      ]}
   *)
 
-  val retinue_preserving_backtrace : ('a, 'b) Effect.Deep.continuation -> (unit -> 'a) -> 'b
+  val finally_preserving_backtrace : ('a, 'b) Effect.Deep.continuation -> (unit -> 'a) -> 'b
   (**
-     A variant of {!val:retinue} that preserves the backtrace of the exception thrown by the expression. I am still not sure whether this is in general a good idea, because the backtrace associated with the original {!val:Effect.perform} could potentially be more useful for debugging than that associated with the {!val:raise} inside the OCaml expression. (This is different from exception handling where original backtraces are probably always better.)
+     A variant of {!val:finally} that preserves the backtrace of the exception thrown by the expression. I am still not sure whether this is in general a good idea, because the backtrace associated with the original {!val:Effect.perform} could potentially be more useful for debugging than that associated with the {!val:raise} inside the OCaml expression. (This is different from exception handling where original backtraces are probably always better.)
      {[
-       Eff.Fun.Deep.retinue_preserving_backtrace k @@ fun () -> some OCaml expression
+       Eff.Fun.Deep.finally_preserving_backtrace k @@ fun () -> some OCaml expression
      ]}
   *)
 end
 
 module Shallow :
 sig
-  val retinue_with : ('a, 'b) Effect.Shallow.continuation -> (unit -> 'a) -> ('b, 'c) Effect.Shallow.handler -> 'c
-  (** See {!val:Deep.retinue}. *)
+  val finally_with : ('a, 'b) Effect.Shallow.continuation -> (unit -> 'a) -> ('b, 'c) Effect.Shallow.handler -> 'c
+  (** See {!val:Deep.finally}. *)
 
-  val retinue_preserving_backtrace_with : ('a, 'b) Effect.Shallow.continuation -> (unit -> 'a) -> ('b, 'c) Effect.Shallow.handler -> 'c
-  (** See {!val:Deep.retinue_preserving_backtrace}. *)
+  val finally_preserving_backtrace_with : ('a, 'b) Effect.Shallow.continuation -> (unit -> 'a) -> ('b, 'c) Effect.Shallow.handler -> 'c
+  (** See {!val:Deep.finally_preserving_backtrace}. *)
 end

--- a/src/Mutex.ml
+++ b/src/Mutex.ml
@@ -17,7 +17,7 @@ struct
       raise Locked
     else begin
       S.set true;
-      Fun.protect ~finally:(fun () -> S.set false) f
+      Stdlib.Fun.protect ~finally:(fun () -> S.set false) f
     end
 
   let run f = S.run ~init:false f


### PR DESCRIPTION
@TOTBWF @cangiuli @jonsterling I need a word that is the combination of "continue" and "discontinue", ideally with some connotation of "redirection" or "resumption".

# What is `Fun.Deep.retinue`?

There are cases where one wants to resume a continuation with an expression, regardless of whether the expression will raise an exception or not. The current OCaml API forces us to choose between `continue` and `discontinue` depending on whether the expression is returning a value or raising an exception. I am tired of writing the boilerplate to redirect the value/exception. This simple function will do the right thing in both cases. Usage:
```ocaml
Eff.Fun.Deep.retinue k @@ fun () -> any OCaml expression
```
A variant of this function would preserve the backtrace of the exception thrown by the expression. I am still not sure whether this is in general a good idea, because the backtrace associated with the original `Effect.perform` could potentially be more useful for debugging than that associated with the `raise` inside the OCaml expression. (This is different from exception handling where original backtraces are probably always better.)
```ocaml
Eff.Fun.Deep.retinue_preserving_backtrace k @@ fun () -> any OCaml expression
```