### PR TITLE
refactor(Mutex): replace Stdlib.Mutex with simple mechanism

### DIFF
--- a/src/Mutex.ml
+++ b/src/Mutex.ml
@@ -1,5 +1,3 @@
-open StdlibShim
-
 module type S =
 sig
   exception RecursiveLocking
@@ -12,28 +10,15 @@ module Make () =
 struct
   exception RecursiveLocking
 
-  type _ Effect.t +=
-    | Lock : unit Effect.t
-    | Unlock : unit Effect.t
+  module S = State.Make(struct type state = bool end)
 
   let exclusively f =
-    Effect.perform Lock;
-    Fun.protect ~finally:(fun () -> Effect.perform Unlock) f
+    if S.get() then
+      raise RecursiveLocking
+    else begin
+      S.set true;
+      Fun.protect ~finally:(fun () -> S.set false) f
+    end
 
-  let run f =
-    let open Effect.Deep in
-    let mutex = Stdlib.Mutex.create () in
-    try_with f ()
-      { effc = fun (type a) (eff : a Effect.t) ->
-            match eff with
-            | Lock -> Option.some @@ fun (k : (a, _) continuation) ->
-              begin
-                match Stdlib.Mutex.lock mutex with
-                | () -> continue k ()
-                | exception Sys_error _ -> discontinue k RecursiveLocking
-              end
-            | Unlock -> Option.some @@ fun (k : (a, _) continuation) ->
-              Stdlib.Mutex.unlock mutex;
-              continue k ()
-            | _ -> None }
+  let run f = S.run ~init:false f
 end


### PR DESCRIPTION
It seems impossible for multiple domains to access the lock at the same time. We thus may avoid the expensive `Stdlib.Mutex`.