### PR TITLE
feat(DeepFork): add DeepFork

### DIFF
--- a/src/Algaeff.ml
+++ b/src/Algaeff.ml
@@ -2,5 +2,7 @@ module State = State
 module Reader = Reader
 module Mutex = Mutex
 module Unmonad = Unmonad
+module WoundSpawn = WoundSpawn
+
 module StdlibShim = StdlibShim
 module Fun = Fun

--- a/src/Algaeff.mli
+++ b/src/Algaeff.mli
@@ -10,6 +10,8 @@ module Mutex : module type of Mutex
 
 module Unmonad : module type of Unmonad
 
+module WoundSpawn : module type of WoundSpawn
+
 (** {1 Auxiliary functions and modules} *)
 
 (** A {!module:Stdlib.Effect} shim for OCaml < 5.

--- a/src/WoundSpawn.ml
+++ b/src/WoundSpawn.ml
@@ -1,0 +1,30 @@
+open StdlibShim
+
+(* an ugly hack before ocaml/ocaml#11159 is resolved *)
+type !'a wrap = Wrap of 'a Domain.t
+
+type _ Effect.t += Spawn : (unit -> 'a) -> 'a wrap Effect.t
+
+let scope ?(at_spawn=Stdlib.Fun.id) ?(at_exit=Stdlib.Fun.id) f =
+  Effect.Deep.try_with f ()
+    { effc =
+        fun (type a) (eff : a Effect.t) ->
+          match eff with
+          | Spawn t -> Option.some @@ fun (k : (a, _) Effect.Deep.continuation) ->
+            Fun.Deep.reperform k @@ Spawn (fun () ->
+                at_spawn ();
+                match t () with
+                | ans -> at_exit (); ans
+                | exception exn -> at_exit (); raise exn)
+          | _ -> None }
+
+let spawn t = match Effect.perform (Spawn t) with Wrap dom -> dom
+
+let run f =
+  Effect.Deep.try_with f ()
+    { effc =
+        fun (type a) (eff : a Effect.t) ->
+          match eff with
+          | Spawn t -> Option.some @@ fun (k : (a, _) Effect.Deep.continuation) ->
+            Fun.Deep.finally k @@ fun () -> Wrap (Domain.spawn t)
+          | _ -> None }

--- a/src/WoundSpawn.mli
+++ b/src/WoundSpawn.mli
@@ -1,0 +1,18 @@
+(** EXPERIMENTAL *)
+
+(** This is like Domain.at_startup and Domain.at_exit, but composable. *)
+
+val scope : ?at_spawn:(unit -> unit) -> ?at_exit:(unit -> unit) -> (unit -> 'a) -> 'a
+(* [scope ~at_spawn ~at_exit f] runs the thunk [f], and for spawn effects performed within [f],
+   the function [at_spawn] will be run at the start of the spawned domain and then
+   [at_exit] at the end of the domain (even when an exception is raised).
+
+   [scope] can be arbitrarily nested: the outermost [at_spawn] will run first
+   and the outermost [at_exit] will run last.
+*)
+
+val spawn : (unit -> 'a) -> 'a Domain.t
+(* [spawn f] spawns a new domain to run [f]. *)
+
+val run : (unit -> 'a) -> 'a
+(* [run f] runs the thunk [f] that may perform spawn effects. *)


### PR DESCRIPTION
This is just a rough idea---use cascading effect handlers to automatically unwind code when spawning a new domain. (It's like `dynamic-wind` in Scheme/Racket, but for new spawned domains, not the current domain.) A more abstract interface might be needed for integration with the library [domainslib](https://github.com/ocaml-multicore/domainslib).