### PR TITLE
feat!: alternative API

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -27,7 +27,7 @@ You need OCaml 5.
 ### Example Code
 
 ```ocaml
-module S = Algaeff.State.Make (struct type state = int end)
+module S = Algaeff.State.Make (Int)
 
 let forty_two = S.run ~init:100 @@ fun () ->
   print_int (S.get ()); (* this will print out 100 *)

--- a/src/Algaeff.ml
+++ b/src/Algaeff.ml
@@ -4,4 +4,5 @@ module Sequencer = Sequencer
 module Mutex = Mutex
 module UniqueID = UniqueID
 module Unmonad = Unmonad
+module Sigs = Sigs
 module Fun = Fun

--- a/src/Algaeff.mli
+++ b/src/Algaeff.mli
@@ -14,6 +14,8 @@ module UniqueID = UniqueID
 
 module Unmonad = Unmonad
 
-(** {1 Auxiliary tools} *)
+(** {1 Auxiliary modules} *)
+
+module Sigs = Sigs
 
 module Fun = Fun

--- a/src/Mutex.ml
+++ b/src/Mutex.ml
@@ -17,7 +17,7 @@ struct
     | Locked -> Some "Mutex already locked"
     | _ -> None
 
-  module S = State.Make(struct type state = bool end)
+  module S = State.Make (Bool)
 
   let exclusively f =
     if S.get() then

--- a/src/Reader.ml
+++ b/src/Reader.ml
@@ -1,27 +1,20 @@
-module type Param =
-sig
-  type env
-end
-
 module type S =
 sig
-  include Param
+  module Env : Sigs.Type
 
-  val read : unit -> env
-  val scope : (env -> env) -> (unit -> 'a) -> 'a
-  val run : env:env -> (unit -> 'a) -> 'a
+  val read : unit -> Env.t
+  val scope : (Env.t -> Env.t) -> (unit -> 'a) -> 'a
+  val run : env:Env.t -> (unit -> 'a) -> 'a
   val register_printer : ([`Read] -> string option) -> unit
 end
 
-module Make (P : Param) =
+module Make (Env : Sigs.Type) =
 struct
-  include P
-
-  type _ Effect.t += Read : env Effect.t
+  type _ Effect.t += Read : Env.t Effect.t
 
   let read () = Effect.perform Read
 
-  let run ~(env:env) f =
+  let run ~(env:Env.t) f =
     let open Effect.Deep in
     try_with f ()
       { effc = fun (type a) (eff : a Effect.t) ->

--- a/src/Reader.mli
+++ b/src/Reader.mli
@@ -2,7 +2,7 @@
 
 (**
    {[
-     module R = Algaeff.Reader.Make (struct type env = int end)
+     module R = Algaeff.Reader.Make (Int)
 
      let () = R.run ~env:42 @@ fun () ->
        (* this will print out 42 *)
@@ -18,28 +18,21 @@
 
 (** This should be equivalent to {!Unmonad} applying to the standard reader monad. *)
 
-module type Param =
-sig
-  (** Parameters of read effects. *)
-
-  type env
-  (** The type of environments. *)
-end
-
 module type S =
 sig
   (** Signatures of read effects. *)
 
-  include Param
+  (** Type of environments. *)
+  module Env : Sigs.Type
   (** @open *)
 
-  val read : unit -> env
+  val read : unit -> Env.t
   (** Read the environment. *)
 
-  val scope : (env -> env) -> (unit -> 'a) -> 'a
+  val scope : (Env.t -> Env.t) -> (unit -> 'a) -> 'a
   (** [scope f t] runs the thunk [t] under the new environment that is the result of applying [f] to the current environment. *)
 
-  val run : env:env -> (unit -> 'a) -> 'a
+  val run : env:Env.t -> (unit -> 'a) -> 'a
   (** [run t] runs the thunk [t] which may perform reading effects. *)
 
   val register_printer : ([`Read] -> string option) -> unit
@@ -51,5 +44,5 @@ sig
   *)
 end
 
-module Make (P : Param) : S with type env = P.env
+module Make (Env : Sigs.Type) : S with module Env := Env
 (** The implementation of read effects. *)

--- a/src/Sequencer.ml
+++ b/src/Sequencer.ml
@@ -1,22 +1,15 @@
-module type Param =
-sig
-  type elt
-end
-
 module type S =
 sig
-  include Param
+  module Elt : Sigs.Type
 
-  val yield : elt -> unit
-  val run : (unit -> unit) -> elt Seq.t
-  val register_printer : ([`Yield of elt] -> string option) -> unit
+  val yield : Elt.t -> unit
+  val run : (unit -> unit) -> Elt.t Seq.t
+  val register_printer : ([`Yield of Elt.t] -> string option) -> unit
 end
 
-module Make (P : Param) =
+module Make (Elt : Sigs.Type) =
 struct
-  include P
-
-  type _ Effect.t += Yield : elt -> unit Effect.t
+  type _ Effect.t += Yield : Elt.t -> unit Effect.t
 
   let yield x = Effect.perform (Yield x)
 

--- a/src/Sequencer.mli
+++ b/src/Sequencer.mli
@@ -3,7 +3,7 @@
 
 (**
    {[
-     module S = Algaeff.Sequencer.Make (struct type elt = int end)
+     module S = Algaeff.Sequencer.Make (Int)
 
      (* The sequence corresponding to [[1; 2; 3]]. *)
      let seq : int Seq.t = S.run @@ fun () -> S.yield 1; S.yield 2; S.yield 3
@@ -15,28 +15,20 @@
 
 (** The sequencers are generators for [Seq.t]. *)
 
-module type Param =
-sig
-  (** Parameters of sequencing effects. *)
-
-  type elt
-  (** The type of elementers. *)
-end
-
 module type S =
 sig
   (** Signatures of sequencing effects. *)
 
-  include Param
+  module Elt : Sigs.Type
   (** @open *)
 
-  val yield : elt -> unit
+  val yield : Elt.t -> unit
   (** Yield the element. *)
 
-  val run : (unit -> unit) -> elt Seq.t
+  val run : (unit -> unit) -> Elt.t Seq.t
   (** [run t] runs the thunk [t] which may perform sequencing effects. *)
 
-  val register_printer : ([`Yield of elt] -> string option) -> unit
+  val register_printer : ([`Yield of Elt.t] -> string option) -> unit
   (** [register_printer p] registers a printer [p] via {!val:Printexc.register_printer} to convert unhandled internal effects into strings for the OCaml runtime system to display. Ideally, all internal effects should have been handled by {!val:run} and there is no need to use this function, but when it is not the case, this function can be helpful for debugging. The functor {!module:Sequencer.Make} always registers a simple printer to suggest using {!val:run}, but you can register new ones to override it. The return type of the printer [p] should return [Some s] where [s] is the resulting string, or [None] if it chooses not to convert a particular effect. The registered printers are tried in reverse order until one of them returns [Some s] for some [s]; that is, the last registered printer is tried first. Note that this function is a wrapper of {!val:Printexc.register_printer} and all the registered printers (via this function or {!val:Printexc.register_printer}) are put into the same list.
 
       The input type of the printer [p] is a variant representation of the internal effects used in this module. They correspond to the effects trigger by {!val:yield}. More precisely, [`Yield elt] corresponds to the effect triggered by [yield elt].
@@ -45,5 +37,5 @@ sig
   *)
 end
 
-module Make (P : Param) : S with type elt = P.elt
+module Make (Elt : Sigs.Type) : S with module Elt := Elt
 (** The implementation of sequencing effects. *)

--- a/src/Sigs.ml
+++ b/src/Sigs.ml
@@ -1,0 +1,8 @@
+(** Common signatures shared across different components. *)
+
+(** A signature carrying a type. *)
+module type Type =
+sig
+  (** The type. *)
+  type t
+end

--- a/src/State.ml
+++ b/src/State.ml
@@ -1,31 +1,24 @@
-module type Param =
-sig
-  type state
-end
-
 module type S =
 sig
-  include Param
+  module State : Sigs.Type
 
-  val get : unit -> state
-  val set : state -> unit
-  val modify : (state -> state) -> unit
-  val run : init:state -> (unit -> 'a) -> 'a
-  val register_printer : ([`Get | `Set of state] -> string option) -> unit
+  val get : unit -> State.t
+  val set : State.t -> unit
+  val modify : (State.t -> State.t) -> unit
+  val run : init:State.t -> (unit -> 'a) -> 'a
+  val register_printer : ([`Get | `Set of State.t] -> string option) -> unit
 end
 
-module Make (P : Param) =
+module Make (State : Sigs.Type) =
 struct
-  include P
-
   type _ Effect.t +=
-    | Get : state Effect.t
-    | Set : state -> unit Effect.t
+    | Get : State.t Effect.t
+    | Set : State.t -> unit Effect.t
 
   let get () = Effect.perform Get
   let set st = Effect.perform (Set st)
 
-  let run ~(init:state) f =
+  let run ~(init:State.t) f =
     let open Effect.Deep in
     let st = ref init in
     try_with f ()

--- a/src/State.mli
+++ b/src/State.mli
@@ -2,7 +2,7 @@
 
 (**
    {[
-     module S = Algaeff.State.Make (struct type state = int end)
+     module S = Algaeff.State.Make (Int)
 
      let forty_two = S.run ~init:100 @@ fun () ->
        print_int (S.get ()); (* this will print out 100 *)
@@ -14,34 +14,26 @@
 (** This should be equivalent to {!module:Unmonad} applying to the standard state monad when continuations are one-shot.
     (The current implementation uses mutable references and this statement has not been formally proved.) *)
 
-module type Param =
-sig
-  (** Parameters of state effects. *)
-
-  type state
-  (** The type of states. *)
-end
-
 module type S =
 sig
   (** Signatures of read effects. *)
 
-  include Param
+  module State : Sigs.Type
   (** @open *)
 
-  val get : unit -> state
+  val get : unit -> State.t
   (** [get ()] reads the current state. *)
 
-  val set : state -> unit
+  val set : State.t -> unit
   (** [set x] makes [x] the new state. *)
 
-  val modify : (state -> state) -> unit
+  val modify : (State.t -> State.t) -> unit
   (** [modify f] applies [f] to the current state and then set the result as the new state. *)
 
-  val run : init:state -> (unit -> 'a) -> 'a
+  val run : init:State.t -> (unit -> 'a) -> 'a
   (** [run t] runs the thunk [t] which may perform state effects. *)
 
-  val register_printer : ([`Get | `Set of state] -> string option) -> unit
+  val register_printer : ([`Get | `Set of State.t] -> string option) -> unit
   (** [register_printer p] registers a printer [p] via {!val:Printexc.register_printer} to convert unhandled internal effects into strings for the OCaml runtime system to display. Ideally, all internal effects should have been handled by {!val:run} and there is no need to use this function, but when it is not the case, this function can be helpful for debugging. The functor {!module:State.Make} always registers a simple printer to suggest using {!val:run}, but you can register new ones to override it. The return type of the printer [p] should return [Some s] where [s] is the resulting string, or [None] if it chooses not to convert a particular effect. The registered printers are tried in reverse order until one of them returns [Some s] for some [s]; that is, the last registered printer is tried first. Note that this function is a wrapper of {!val:Printexc.register_printer} and all the registered printers (via this function or {!val:Printexc.register_printer}) are put into the same list.
 
       The input type of the printer [p] is a variant representation of the internal effects used in this module. They correspond to the effects trigger by {!val:get} and {!val:set}. More precisely,
@@ -52,5 +44,5 @@ sig
   *)
 end
 
-module Make (P : Param) : S with type state = P.state
+module Make (State : Sigs.Type) : S with module State := State
 (** The implementation of state effects. *)

--- a/src/UniqueID.mli
+++ b/src/UniqueID.mli
@@ -3,19 +3,11 @@
 
 (** Generate unique IDs for registered items. *)
 
-module type Param =
-sig
-  (** Parameters of the effects. *)
-
-  type elt
-  (** The type of elements. *)
-end
-
 module type S =
 sig
   (** Signatures of the effects. *)
 
-  include Param
+  module Elt : Sigs.Type
   (** @open *)
 
   (** The type of IDs and its friends. *)
@@ -40,22 +32,22 @@ sig
   type id = ID.t
   (** The type of unique IDs. The client should not assume a particular indexing scheme. *)
 
-  val register : elt -> id
+  val register : Elt.t -> id
   (** Register a new item and get an ID. Note that registering the same item twice will get two different IDs. *)
 
-  val retrieve : id -> elt
+  val retrieve : id -> Elt.t
   (** Retrieve the item associated with the ID. *)
 
-  val export : unit -> elt Seq.t
+  val export : unit -> Elt.t Seq.t
   (** Export the internal storage for serialization. Once exported, the representation is persistent and can be traversed without the effect handler. *)
 
-  val run : ?init:elt Seq.t -> (unit -> 'a) -> 'a
+  val run : ?init:Elt.t Seq.t -> (unit -> 'a) -> 'a
   (** [run t] runs the thunk [t] and handles the effects for generating unique IDs.
 
       @param init The initial storage, which should be the output of some previous {!val:export}.
   *)
 
-  val register_printer : ([`Register of elt | `Retrieve of id | `Export] -> string option) -> unit
+  val register_printer : ([`Register of Elt.t | `Retrieve of id | `Export] -> string option) -> unit
   (** [register_printer p] registers a printer [p] via {!val:Printexc.register_printer} to convert unhandled internal effects into strings for the OCaml runtime system to display. Ideally, all internal effects should have been handled by {!val:run} and there is no need to use this function, but when it is not the case, this function can be helpful for debugging. The functor {!module:UniqueID.Make} always registers a simple printer to suggest using {!val:run}, but you can register new ones to override it. The return type of the printer [p] should return [Some s] where [s] is the resulting string, or [None] if it chooses not to convert a particular effect. The registered printers are tried in reverse order until one of them returns [Some s] for some [s]; that is, the last registered printer is tried first. Note that this function is a wrapper of {!val:Printexc.register_printer} and all the registered printers (via this function or {!val:Printexc.register_printer}) are put into the same list.
 
       The input type of the printer [p] is a variant representation of the internal effects used in this module. They correspond to the effects trigger by {!val:register}, {!val:retrieve} and {!val:export}. More precisely,
@@ -67,5 +59,5 @@ sig
   *)
 end
 
-module Make (P : Param) : S with type elt = P.elt
+module Make (Elt : Sigs.Type) : S with module Elt := Elt
 (** The implementation of the effects. *)

--- a/src/Unmonad.mli
+++ b/src/Unmonad.mli
@@ -63,5 +63,5 @@ sig
       and then returns the corresponding monadic expression. *)
 end
 
-module Make (M : Monad) : S with type 'a t = 'a M.t
+module Make (M : Monad) : S with type 'a t := 'a M.t
 (** The implementation of monad effects. *)

--- a/test/Example.ml
+++ b/test/Example.ml
@@ -1,4 +1,4 @@
-module S = Algaeff.State.Make (struct type state = int end)
+module S = Algaeff.State.Make (Int)
 
 let forty_two = S.run ~init:100 @@ fun () ->
   print_int (S.get ()); (* this will print out 100 *)

--- a/test/TestReader.ml
+++ b/test/TestReader.ml
@@ -1,6 +1,6 @@
 module Q = QCheck2
 
-module ReaderEff = Algaeff.Reader.Make (struct type env = int end)
+module ReaderEff = Algaeff.Reader.Make (Int)
 
 module ReaderMonad =
 struct
@@ -14,7 +14,6 @@ end
 module ReaderUnmonad =
 struct
   module U = Algaeff.Unmonad.Make (ReaderMonad)
-  type env = int
   let read () = U.perform ReaderMonad.read
   let scope f m = U.perform @@ ReaderMonad.scope f @@ U.run m
   let run ~env f = U.run f env
@@ -39,7 +38,7 @@ let gen_cmd =
 
 let gen_prog = Q.Gen.list gen_cmd
 
-module ReaderTester (S : Algaeff.Reader.S with type env = int) =
+module ReaderTester (S : Algaeff.Reader.S with module Env := Int) =
 struct
   let trace ~env prog =
     let rec go =

--- a/test/TestSequencer.ml
+++ b/test/TestSequencer.ml
@@ -1,6 +1,6 @@
 module Q = QCheck2
 
-module SequencerEff = Algaeff.Sequencer.Make (struct type elt = int end)
+module SequencerEff = Algaeff.Sequencer.Make (Int)
 
 type 'a output = Leaf of 'a list | Branch of 'a output * 'a output
 
@@ -23,7 +23,6 @@ end
 module SequencerUnmonad =
 struct
   module U = Algaeff.Unmonad.Make (SequencerMonad)
-  type elt = int
   let yield x = U.perform (SequencerMonad.yield x)
   let run f = output_to_seq @@ snd @@ U.run f
   let register_printer _ = ()
@@ -35,7 +34,7 @@ and prog = cmd list
 let gen_cmd = Q.Gen.map (fun i -> Yield i) Q.Gen.int
 let gen_prog = Q.Gen.list gen_cmd
 
-module SequencerTester (S : Algaeff.Sequencer.S with type elt = int) =
+module SequencerTester (S : Algaeff.Sequencer.S with module Elt := Int) =
 struct
   let trace (prog : prog) =
     let go = function (Yield i) -> S.yield i in

--- a/test/TestState.ml
+++ b/test/TestState.ml
@@ -1,6 +1,6 @@
 module Q = QCheck2
 
-module StateEff = Algaeff.State.Make (struct type state = int end)
+module StateEff = Algaeff.State.Make (Int)
 
 module StateMonad =
 struct
@@ -15,7 +15,6 @@ end
 module StateUnmonad =
 struct
   module U = Algaeff.Unmonad.Make (StateMonad)
-  type state = int
   let get () = U.perform StateMonad.get
   let set s = U.perform @@ StateMonad.set s
   let modify f = U.perform @@ StateMonad.modify f
@@ -34,7 +33,7 @@ let gen_cmd =
 
 let gen_prog = Q.Gen.list gen_cmd
 
-module StateTester (S : Algaeff.State.S with type state = int) =
+module StateTester (S : Algaeff.State.S with module State := Int) =
 struct
   let trace ~init prog =
     let go =

--- a/test/TestUniqueID.ml
+++ b/test/TestUniqueID.ml
@@ -1,6 +1,6 @@
 module Q = QCheck2
 
-module U = Algaeff.UniqueID.Make (struct type elt = int end)
+module U = Algaeff.UniqueID.Make (Int)
 
 let test_uniqueness =
   Q.Test.make ~name:"UniqueID:uniqueness" Q.Gen.(list int)


### PR DESCRIPTION
This breaking change is to allow code like these:
```ocaml
module S = Algaeff.State.Make (Int)
module R = Algaeff.Reader.Make (Int)
module S = Algaeff.Sequencer.Make (Int)
module U = Algaeff.UniqueID.Make (Int)
```
I don't feel the convenience is worth the trouble (which includes manually adding upper bound to all forester/asai/yuujinchou releases), but also why not...