### PR TITLE
feature request: allow caller to override state handlers

### DIFF
--- a/src/State.ml
+++ b/src/State.ml
@@ -5,7 +5,7 @@ sig
   val set : state -> unit
   val modify : (state -> state) -> unit
   val run : init:state -> (unit -> 'a) -> 'a
-  val try_with : get:(unit -> state) -> set:(state -> unit) -> (unit -> 'a) -> 'a
+  val try_with : ?get:(unit -> state) -> ?set:(state -> unit) -> (unit -> 'a) -> 'a
   val register_printer : ([`Get | `Set of state] -> string option) -> unit
 end
 
@@ -30,7 +30,7 @@ struct
               st := v; continue k ()
             | _ -> None }
 
-  let try_with ~(get:unit -> State.t) ~(set:State.t -> unit) f =
+  let try_with ?(get=get) ?(set=set) f =
     let open Effect.Deep in
     try_with f ()
       { effc = fun (type a) (eff : a Effect.t) ->

--- a/src/State.ml
+++ b/src/State.ml
@@ -5,6 +5,7 @@ sig
   val set : state -> unit
   val modify : (state -> state) -> unit
   val run : init:state -> (unit -> 'a) -> 'a
+  val try_with : get:(unit -> state) -> set:(state -> unit) -> (unit -> 'a) -> 'a
   val register_printer : ([`Get | `Set of state] -> string option) -> unit
 end
 
@@ -27,6 +28,17 @@ struct
               continue k !st
             | Set v -> Option.some @@ fun (k : (a, _) continuation) ->
               st := v; continue k ()
+            | _ -> None }
+
+  let try_with ~(get:unit -> State.t) ~(set:State.t -> unit) f =
+    let open Effect.Deep in
+    try_with f ()
+      { effc = fun (type a) (eff : a Effect.t) ->
+            match eff with
+            | Get -> Option.some @@ fun (k : (a, _) continuation) ->
+              continue k (get ())
+            | Set v -> Option.some @@ fun (k : (a, _) continuation) ->
+              set v; continue k ()
             | _ -> None }
 
   let modify f = set @@ f @@ get ()

--- a/src/State.mli
+++ b/src/State.mli
@@ -30,8 +30,8 @@ sig
   val run : init:state -> (unit -> 'a) -> 'a
   (** [run ~init t] runs the thunk [t] which may perform state effects. The initial state is [init]. *)
 
-  val try_with : get:(unit -> state) -> set:(state -> unit) -> (unit -> 'a) -> 'a
-  (** [try_with ~get ~set t] runs the thunk [t] which may perform state effects, handling these effects with [get] and [set] (which may perform effects from some other module). *)
+  val try_with : ?get:(unit -> state) -> ?set:(state -> unit) -> (unit -> 'a) -> 'a
+  (** [try_with ~get ~set t] runs the thunk [t] which may perform state effects, handling these effects with [get] and [set] (which may perform effects from some other module). The default handlers re-perform the effects. *)
 
   val register_printer : ([`Get | `Set of state] -> string option) -> unit
   (** [register_printer p] registers a printer [p] via {!val:Printexc.register_printer} to convert unhandled internal effects into strings for the OCaml runtime system to display. Ideally, all internal effects should have been handled by {!val:run} and there is no need to use this function, but when it is not the case, this function can be helpful for debugging. The functor {!module:Make} always registers a simple printer to suggest using {!val:run}, but you can register new ones to override it. The return type of the printer [p] should return [Some s] where [s] is the resulting string, or [None] if it chooses not to convert a particular effect. The registered printers are tried in reverse order until one of them returns [Some s] for some [s]; that is, the last registered printer is tried first. Note that this function is a wrapper of {!val:Printexc.register_printer} and all the registered printers (via this function or {!val:Printexc.register_printer}) are put into the same list.

--- a/src/State.mli
+++ b/src/State.mli
@@ -30,6 +30,9 @@ sig
   val run : init:state -> (unit -> 'a) -> 'a
   (** [run ~init t] runs the thunk [t] which may perform state effects. The initial state is [init]. *)
 
+  val try_with : get:(unit -> state) -> set:(state -> unit) -> (unit -> 'a) -> 'a
+  (** [try_with ~get ~set t] runs the thunk [t] which may perform state effects, handling these effects with [get] and [set] (which may perform effects from some other module). *)
+
   val register_printer : ([`Get | `Set of state] -> string option) -> unit
   (** [register_printer p] registers a printer [p] via {!val:Printexc.register_printer} to convert unhandled internal effects into strings for the OCaml runtime system to display. Ideally, all internal effects should have been handled by {!val:run} and there is no need to use this function, but when it is not the case, this function can be helpful for debugging. The functor {!module:Make} always registers a simple printer to suggest using {!val:run}, but you can register new ones to override it. The return type of the printer [p] should return [Some s] where [s] is the resulting string, or [None] if it chooses not to convert a particular effect. The registered printers are tried in reverse order until one of them returns [Some s] for some [s]; that is, the last registered printer is tried first. Note that this function is a wrapper of {!val:Printexc.register_printer} and all the registered printers (via this function or {!val:Printexc.register_printer}) are put into the same list.
 

--- a/test/TestState.ml
+++ b/test/TestState.ml
@@ -19,7 +19,7 @@ struct
   let set s = U.perform @@ StateMonad.set s
   let modify f = U.perform @@ StateMonad.modify f
   let run ~init f = fst @@ U.run f init
-  let try_with ~get:_ ~set:_ _f = raise (Failure "state monad can't try_with")
+  let try_with ?get:_ ?set:_ _f = failwith "state monad can't try_with"
   let register_printer _ = ()
 end
 

--- a/test/TestState.ml
+++ b/test/TestState.ml
@@ -19,6 +19,7 @@ struct
   let set s = U.perform @@ StateMonad.set s
   let modify f = U.perform @@ StateMonad.modify f
   let run ~init f = fst @@ U.run f init
+  let try_with ~get:_ ~set:_ _f = raise (Failure "state monad can't try_with")
   let register_printer _ = ()
 end
 


### PR DESCRIPTION
This is more of a feature request than a pull request, but the clearest way to explain what I mean is to supply some example code.  If you like the idea, feel free to implement it some other way and/or with some other name.

What I want is a State effect module that allows the caller to override its handlers.  In general, the caller's ability to supply their own handlers is one of the strengths of algebraic effects, right?  So while it makes sense to supply a standard handler, I think it would also make sense to supply a way to use a caller-supplied handler, without forcing the caller to use the currently-ugly `try_with` OCaml builtin.

The reason I want this at the moment is that I have modules `A` and `B`, say, which have their own instances of State, say `A.S` and `B.S`.  Then any code that uses both of them has be wrapped in `A.run ~init:inita @@ fun () -> B.run ~init:initb @@ fun () ->`.  I'd like to instead have a single outer state instance that stores both states together, say `C` with `C.state = {a : A.state; b : B.state}`, and define `C.run` to wrap its argument in both `A.handle` and `B.handle` that pass off to the components of the `C` state.  Then the actual caller can just call `C.run`.

One thing that's nice about this is that if there are multiple places calling `run`, then adding a new state-using module alongside `A` and `B` will only require changing the definition of `C.run` rather than having to make sure to find all the places where `A.run` and `B.run` are called to add another module's `run` also.  But more importantly, `C` can do fancier things than just storing a single copy of the two states, such as maintaining an undo buffer for both states together, without needing to pollute the code of `A` or `B` with that logic.